### PR TITLE
can now do basic dnd dice rolls

### DIFF
--- a/bot/commands/utility/diceRoll.js
+++ b/bot/commands/utility/diceRoll.js
@@ -36,25 +36,31 @@ module.exports = {
     args: false,
     name: 'roll',
     botAdmin: false,
-    description: 'roles a 6 sided die, optionally can specify the number of sides',
-    usage: '[<numSides>]',
+    description: 'roles a 6 sided die, optionally can specify a number of sided dice for DND with a modifier',
+    usage: '[<numDice>d<numSides> +- <optional modifier>]',
     aliases: [],
     execute: diceRoleCommand,
     docs: `#### Roll dice
 - Command: \`roll\`
-- Returns: randomly generated number from 1 to 6, or 1 to N
+- Returns: Rolls some dice and adds an optional modifier to the result
 - Example usage:
 \`\`\`
 User
 > !roll
 
 Botomir
-> 🎲 1
+> 🎲 (1) + 0 = 1
 
 User
-> !roll 100
+> !roll 1d20
 
 Botomir
-> 🎲 48
+> 🎲 (11) + 0 = 11
+
+User
+> !roll 3d10 + 4
+
+Botomir
+> 🎲 (3, 5, 4) + 4 = 16
 \`\`\``,
 };

--- a/bot/commands/utility/diceRoll.js
+++ b/bot/commands/utility/diceRoll.js
@@ -5,13 +5,31 @@ const { sendMessage } = source('bot/utils/util');
 
 const generator = new Random();
 
+const diceRegex = /^([0-9]*)d([0-9]{0,3})([+-][0-9]+)?$/;
+
 function diceRoleCommand(message, args) {
-    const sides = Number.parseInt(args[0], 10) || 6;
+    const dice = args.join('');
 
-    if (sides <= 1) return sendMessage(message.channel, `Sorry I can't figure out how to role a ${sides} die.`);
+    const parts = diceRegex.exec(dice);
 
-    const number = Math.trunc(generator.integer(0, sides)) + 1;
-    return sendMessage(message.channel, `:game_die: ${number}`);
+    let num = 1;
+    let sides = 6;
+    let modifier = 0;
+
+    if (parts !== null) {
+        num = Number.parseInt(parts[1], 10) || 1;
+        sides = Number.parseInt(parts[2], 10) || 6;
+        modifier = Number.parseInt(parts[3], 10) || 0;
+    }
+    const results = [];
+
+    for (let i = 0; i <= num; i += 1) {
+        results.push(Math.trunc(generator.integer(0, sides)) + 1);
+    }
+
+    const total = results.reduce((a, v) => a + v, modifier);
+
+    return sendMessage(message.channel, `:game_die: (${results.join(', ')}) + ${modifier} = ${total}`);
 }
 
 module.exports = {


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: #165 
Fixes: # <!-- number of issue (implies Closes tag) or commit SHA -->\
Related: # <!-- number of issue/pull request, or link to external discussion -->

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

This should allow botomir to roll dice for DND `!roll 5d20` `!roll 2d10 + 3` .... or just plain old `!roll`

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Run `npm run lint` and ensure linter passes
- [x] Run `npm run test` and ensure tests pass
- [x] Verify that the changes work as expected on Discord
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable 
