### PR TITLE
fixed the NaN issue when too many dice are rolled

### DIFF
--- a/bot/commands/utility/diceRoll.js
+++ b/bot/commands/utility/diceRoll.js
@@ -21,12 +21,17 @@ function diceRoleCommand(message, args) {
         sides = Number.parseInt(parts[2], 10) || 6;
         modifier = Number.parseInt(parts[3], 10) || 0;
     }
-    const results = [];
 
-    for (let i = 0; i <= num; i += 1) {
-        results.push(Math.trunc(generator.integer(0, sides)) + 1);
+    if (num > 100) {
+        return sendMessage(message.channel, "That is too many dice to roll at once, please don't do more than 100 at a time");
     }
 
+    const nums = generator.integers(1, sides+1, num);
+    if (nums instanceof Array === false) {
+        return sendMessage(message.channel, "Oh no something went wrong!!! I can't seem to find my dice");
+    }
+
+    const results = nums.map((n) => Math.trunc(n));
     const total = results.reduce((a, v) => a + v, modifier);
 
     return sendMessage(message.channel, `:game_die: (${results.join(', ')}) + ${modifier} = ${total}`);

--- a/bot/commands/utility/diceRoll.js
+++ b/bot/commands/utility/diceRoll.js
@@ -26,7 +26,7 @@ function diceRoleCommand(message, args) {
         return sendMessage(message.channel, "That is too many dice to roll at once, please don't do more than 100 at a time");
     }
 
-    const nums = generator.integers(1, sides+1, num);
+    const nums = generator.integers(1, sides + 1, num);
     if (nums instanceof Array === false) {
         return sendMessage(message.channel, "Oh no something went wrong!!! I can't seem to find my dice");
     }


### PR DESCRIPTION
Closes: #180 
---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

This should fix some of the problems and clean up the code a little bit. the NaN issue is related to how the random number library caches the random numbers and it is non blocked if it does not have enough. That underlying problem can be fixed but its not quite within the scope of this project so this is a work arround. 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Run `npm run lint` and ensure linter passes
- [x] Run `npm run test` and ensure tests pass
- [x] Verify that the changes work as expected on Discord
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable 
