### PR TITLE
Fixed the admin role being ignored

### DIFF
--- a/bot/commands/information/help.js
+++ b/bot/commands/information/help.js
@@ -1,7 +1,6 @@
 const source = require('rfr');
 
 const { sendMessage } = source('bot/utils/util');
-const { findRole } = source('bot/roles/roles');
 
 const helpEmbeded = {
     color: 0x0099ff,
@@ -30,7 +29,7 @@ function sendChunks(channel, fields, categoryName) {
 }
 
 function helpGeneral(message, commands, config, category) {
-    const isAdmin = findRole(message.member, config.botAdminRole);
+    const isAdmin = message.member.roles.cache.map((r) => r.name).includes(config.botAdminRole);
 
     const fields = commands.filter((c) => !config.disabledCommands.includes(c.name))
         .filter((c) => !(c.botAdmin && !isAdmin))
@@ -53,8 +52,10 @@ function helpSpecific(message, command, config) {
             + 'contact one of the server admins if you think this is a mistake!');
     }
 
-    // dont provide help if the user is not authorized for that command
-    if (command.botAdmin && !findRole(message.member, config.botAdminRole)) {
+    const isAdmin = message.member.roles.cache.map((r) => r.name).includes(config.botAdminRole);
+
+    // don't provide help if the user is not authorized for that command
+    if (command.botAdmin && !isAdmin) {
         return sendMessage(message.channel, `You are not authorized to use the ${command.name} command`);
     }
 

--- a/bot/reactions/roleReaction.js
+++ b/bot/reactions/roleReaction.js
@@ -1,14 +1,27 @@
 const source = require('rfr');
 
 const { changeRole, findRole, Mode } = source('bot/roles/roles');
+const logger = source('bot/utils/logger');
 
 function addRoleReactionHandler(member, roleName) {
     const role = findRole(member, roleName);
+
+    if (!role) {
+        logger.error(`Cant add the role named ${roleName} from ${member.id}, the role does not exist`);
+        return;
+    }
+
     changeRole(member, role, Mode.ADD);
 }
 
 function removeRoleReactionHandler(member, roleName) {
     const role = findRole(member, roleName);
+
+    if (!role) {
+        logger.error(`Cant remove the role named ${roleName} from ${member.id}, the role does not exist`);
+        return;
+    }
+
     changeRole(member, role, Mode.REMOVE);
 }
 

--- a/bot/scanner/commandHandler.js
+++ b/bot/scanner/commandHandler.js
@@ -4,7 +4,6 @@ const Discord = require('discord.js');
 
 const { Settings } = source('models/settings');
 const { sendMessage } = source('bot/utils/util');
-const { findRole } = source('bot/roles/roles');
 const { Statistics, EventTypes } = source('models/statistics');
 
 const logger = source('bot/utils/logger');
@@ -63,7 +62,9 @@ function commandHandler(message) {
                 return sendMessage(message.channel, reply);
             }
 
-            if (command.botAdmin && !findRole(message.member, config.botAdminRole)) {
+            const roleNames = message.member.roles.cache.map((r) => r.name);
+
+            if (command.botAdmin && !roleNames.includes(config.botAdminRole)) {
                 const reply = `You must have the ${config.botAdminRole} to use this command!`;
                 return sendMessage(message.channel, reply);
             }


### PR DESCRIPTION
admin role checking now works and role reactions give an error if the role name does not exist


---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Run `npm run lint` and ensure linter passes
- [ ] Run `npm run test` and ensure tests pass
- [ ] Verify that the changes work as expected on Discord
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable 
