### PR TITLE
Now replies to message links sent by bot users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - can automatically render message links 
 - can automatically assign roles based on reactions to a message
 - can generate Spotify playlists
-<<<<<<< HEAD
 - added TypeScript compilation to the project
-=======
 - can keep track of message updates
 - can keep track of message deletion
 
->>>>>>> 95c59b5a118604b8be56110abc7786c3092a92d5
 
 ### Changed
 - now uses a database for the bot configuration and not config file
@@ -32,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - server weather command location can be configured
 - DMs no longer cause the app to crash
 - docker image now uses TypeScript compiled application and minimum set of files
+- message link rendering is now also shown for bot users
 
 ## [2.0.1] - 2020-12-20
 ### Changed

--- a/bot/events/messageLinkHandler.js
+++ b/bot/events/messageLinkHandler.js
@@ -7,7 +7,7 @@ const logger = source('bot/utils/logger');
 const messageLinkRegex = /https:\/\/discord.com\/channels\/([0-9]*)\/([0-9]*)\/([0-9]*)/;
 
 function messageLink(message) {
-    if (message.guild === null || message.author.bot) return;
+    if (message.guild === null) return;
     const parts = messageLinkRegex.exec(message.content);
     if (parts === null || parts.length !== 4) return;
 


### PR DESCRIPTION

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

message link handler can now respond to links sent by bot users, this will come in handly when botomir sends message links to produce constant formatting

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Run `npm run lint` and ensure linter passes
- [x] Run `npm run test` and ensure tests pass
- [x] Verify that the changes work as expected on Discord
- [x] Update documentation / not applicable
- [x] Update changelog / not applicable 
