### PR TITLE
updated public facing guild references to say server

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,4 +9,4 @@ Include the following information in your issue:
 - Describe the bug in as much detail as possible
 - What commands you executed, what was teh expected behaviour, and what was observed instead
 - How to reproduce this error
-- Which server did this bug occur on, the date and time. Specify the guild id if you know what it is
+- Which server did this bug occur on, the date and time. Specify the server id if you know what it is

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ In order to use any of the bot configuration commands you must have the role `bo
 - You can add functionality for reactions to specified messages under `lib/reactions/botReactions.js` and a corresponding module.
 
 #### Backup Messages
-- Each message will be written to MongoDB. Data includes guild, channel, author, content, timestamp, and message id.
+- Each message will be written to MongoDB. Data includes server, channel, author, content, timestamp, and message id.
 - Each Spotify track that is sent to the `DISCORD_MUSIC_CHANNEL_ID` will be stored in the database.
 - An authenticate token database will also be maintained for Spotify access tokens.
 - You can specify a different schema or database under `lib/database`.

--- a/app.js
+++ b/app.js
@@ -40,8 +40,8 @@ const discordStrat = new DiscordStrategy({
     // store the user info here????
 
     const userGuildIDs = profile.guilds.map((g) => g.id);
-    const servers = Bot.client.guilds.cache.filter((guild) => userGuildIDs.includes(guild.id));
-    profile.guilds = servers;
+    const guilds = Bot.client.guilds.cache.filter((guild) => userGuildIDs.includes(guild.id));
+    profile.guilds = guilds;
 
     return done(null, profile);
 });

--- a/bot/index.js
+++ b/bot/index.js
@@ -32,13 +32,13 @@ eventFiles.forEach((file) => {
 // joined a server
 client.on('guildCreate', (guild) => {
     logger.info(`Joined a new guild: ${guild.name}`);
-    sendEventMessage(client, `Botomir has joined the \`${guild.name}\` guild!! We are now in ${client.guilds.cache.size} guilds`);
+    sendEventMessage(client, `Botomir has joined the \`${guild.name}\` server!! We are now in ${client.guilds.cache.size} servers`);
 });
 
 // removed from a server
 client.on('guildDelete', (guild) => {
     logger.info(`removed from a guild: ${guild.name}`);
-    sendEventMessage(client, `Botomir has left \`${guild.name}\` :cry:  We are now in ${client.guilds.cache.size} guilds`);
+    sendEventMessage(client, `Botomir has left \`${guild.name}\` :cry:  We are now in ${client.guilds.cache.size} servers`);
 });
 
 client.on('error', (err) => {


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: #206 
---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

Discord calls the servers guilds, but they are called servers to the users, so I have updated the message references to say server instead of guild

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Run `npm run lint` and ensure linter passes
- [x] Run `npm run test` and ensure tests pass
- [x] Verify that the changes work as expected on Discord
- [x] Update documentation / not applicable
- [x] Update changelog / not applicable 
