### PR TITLE
Can now check what version of botomir is running

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,6 +64,10 @@ jobs:
           heroku_app_name: ${{secrets.HEROKU_APP_NAME}}
           heroku_email: ${{secrets.HEROKU_APP_EMAIL}}
           usedocker: true
+          docker_build_args: |
+            COMMIT
+          env:
+            - COMMIT=$GITHUB_SHA
           env_file: ".env"
 
   docker:
@@ -84,5 +88,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          build-args:
+            - COMMIT=$GITHUB_SHA
           push: true
           tags: marshallasch/botomir:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,6 +92,10 @@ jobs:
           heroku_app_name: ${{secrets.HEROKU_APP_NAME}}
           heroku_email: ${{secrets.HEROKU_APP_EMAIL}}
           usedocker: true
+          docker_build_args: |
+            COMMIT
+          env:
+            - COMMIT=$GITHUB_SHA
           env_file: ".env"
 
   docker:
@@ -113,4 +117,6 @@ jobs:
         with:
           context: .
           push: true
+          build-args:
+            - COMMIT=$GITHUB_SHA
           tags: marshallasch/botomir:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added listing the scheduled recurring messages
 - added listing the reminder messages
 - added removing a scheduled recurring message
+- added get version command to check the version of the running code
 - can automatically render message links 
 - can automatically assign roles based on reactions to a message
 - can generate Spotify playlists

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN npm run build
 
 FROM node:14
 
+ARG COMMIT=0
+ENV COMMIT=$COMMIT
+
 WORKDIR /usr/src/app
 
 COPY --from=BUILD /usr/src/app/package*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm run build
 
 FROM node:14
 
-ARG COMMIT=0
+ARG COMMIT='unknown'
 ENV COMMIT=$COMMIT
 
 WORKDIR /usr/src/app

--- a/bot/commands/information/version.js
+++ b/bot/commands/information/version.js
@@ -1,0 +1,31 @@
+const source = require('rfr');
+
+const { version } = source('package');
+const { sendMessage } = source('bot/utils/util');
+const commit = (process.env.COMMIT || 'unknown').slice(0, 7);
+
+function versionCommand(message) {
+    sendMessage(message.channel, `Version: \`${version}\`\nBuild: \`${commit}\``);
+}
+
+module.exports = {
+    args: false,
+    name: 'version',
+    botAdmin: false,
+    description: 'Send the running Botomir version information',
+    usage: '',
+    aliases: [],
+    execute: versionCommand,
+    docs: `#### Version
+- Command: \`version\`
+- Returns: a message with the version number
+- Example usage:
+\`\`\`
+User
+> !version
+
+Botomir
+> Version: \`1.2.3\`
+Build: \`4ba590e\`
+\`\`\``,
+};


### PR DESCRIPTION
added the command to send back the version number / git commit hash of the code that is running

<!-- Tags (fill and keep as many as applicable) -->

Closes: #236 

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

Im not certain that the commit has will get set properly in the build pipeline, but it will give a build number back

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Run `npm run lint` and ensure linter passes
- [x] Run `npm run test` and ensure tests pass
- [x] Verify that the changes work as expected on Discord
- [x] Update documentation / not applicable
- [x] Update changelog / not applicable 
