### PR TITLE
added the users tag to the audit messages that get sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - delete now mentions the user that deleted the messages
 - message link rendering is now also shown for bot users
 - message logging happens for bot users as well
+- Audit messages now include the user tag
 
 ## [2.0.1] - 2020-12-20
 ### Changed

--- a/bot/events/messageDeleteAuditSend.js
+++ b/bot/events/messageDeleteAuditSend.js
@@ -24,7 +24,7 @@ function auditHandler(message, client) {
             return guild.members.fetch(m.authorID);
         })
         .then((u) => {
-            if (u) username = u.user.username;
+            if (u) username = `${u.user.username}#${u.user.discriminator}`;
             return Settings.getServerSettings(message.guild.id);
         })
         .then((config) => {

--- a/bot/events/messageUpdateAuditSend.js
+++ b/bot/events/messageUpdateAuditSend.js
@@ -40,7 +40,7 @@ function auditHandler(oldM, newM) {
             }
 
             const time = moment(newM.editedAt).format('MMMM Do YYYY, HH:mm:ssZ');
-            sendMessage(channel, `**UPDATED**\nauthor: ${message.author.username}\nChannel: <#${message.channel.id}>\nAt: ${time}\nOld Content: ${oldContent}\nNew Content: ${message.content}`);
+            sendMessage(channel, `**UPDATED**\nauthor: ${message.author.username}#${message.author.discriminator}\nChannel: <#${message.channel.id}>\nAt: ${time}\nOld Content: ${oldContent}\nNew Content: ${message.content}`);
         })
         .catch((e) => {
             logger.error('failed to send the update message to the audit channel');


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: #246 

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

fixed an issue where a user can impersonate another user in the audit log

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Run `npm run lint` and ensure linter passes
- [x] Run `npm run test` and ensure tests pass
- [x] Verify that the changes work as expected on Discord
- [x] Verify that the changes work as expected when run using docker
- [x] Update documentation / not applicable
- [x] Update changelog / not applicable
