### PR TITLE
248 fixed category and command naming conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - can keep track of message deletion
 - can send message edits and deletions to a configurable audit channel
 - can configure the server timezone
+- added a warning to be shown if a command name and a command category share the same name, this would cause issues for the help command
 
 
 ### Changed

--- a/bot/events/commandSetup.js
+++ b/bot/events/commandSetup.js
@@ -2,6 +2,19 @@ const source = require('rfr');
 const fs = require('fs');
 const Discord = require('discord.js');
 
+const logger = source('bot/utils/logger');
+
+function checkNameConflicts(categories, commandNames) {
+    return categories.reduce((previous, category) => {
+        if (commandNames.includes(category)) {
+            logger.warn(`A command and a command category have the same name: '${category}', this will prevent help messages from loading correctly.`);
+            return true;
+        }
+
+        return previous;
+    }, false);
+}
+
 function setupCommands(client) {
     client.commands = new Discord.Collection();
 
@@ -18,6 +31,9 @@ function setupCommands(client) {
             client.commands.set(command.name, command);
         });
     });
+
+    // show warnings if a command and a category have the same name
+    checkNameConflicts(categories, client.commands.map((c) => c.name));
 
     client.categories = categories;
 }


### PR DESCRIPTION
added a warning message on startup to indicate if the command and category have the same name

<!-- Tags (fill and keep as many as applicable) -->

Closes: #248 
Related: #249, #251

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

When a command has the same name as a command category the help message that is shown is incorrect.
You are unable to view the help command for the category. 
To fix this, the conflicting commands have been renamed. 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Run `npm run lint` and ensure linter passes
- [x] Run `npm run test` and ensure tests pass
- [x] Verify that the changes work as expected on Discord
- [x] Verify that the changes work as expected when run using docker
- [x] Update documentation / not applicable
- [x] Update changelog / not applicable
