### PR TITLE
#303: webhooks can now be sent via GET requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added listing the reminder messages
 - added removing a scheduled recurring message
 - added get version command to check the version of the running code
-- can automatically render message links 
+- can automatically render message links
 - can automatically assign roles based on reactions to a message
 - can generate Spotify playlists
 - added TypeScript compilation to the project
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added a warning to be shown if a command name and a command category share the same name, this would cause issues for the help command
 - Added message response to whenever botomir gets mentioned
 - Added support for custom webhooks
+- Added support for webhooks using GET or POST requests
 
 ### Changed
 - now uses a database for the bot configuration and not config file

--- a/models/webhook/schema.js
+++ b/models/webhook/schema.js
@@ -43,6 +43,11 @@ module.exports = new mongoose.Schema({
         type: String,
         required: true,
     },
+    method: {
+        type: String,
+        enum: ['GET', 'POST'],
+        default: 'POST',
+    },
     secret: {
         type: String,
         required: true,
@@ -52,5 +57,4 @@ module.exports = new mongoose.Schema({
         type: Date,
         default: Date.now,
     },
-
 });

--- a/models/webhook/webhook.js
+++ b/models/webhook/webhook.js
@@ -38,6 +38,10 @@ class Webhook {
         return this._model.hook_provider;
     }
 
+    get method() {
+        return this._model.method;
+    }
+
     get secret() {
         return this._model.secret;
     }
@@ -74,6 +78,13 @@ class Webhook {
         return this;
     }
 
+    setMethod(method) {
+        if (typeof method === 'string') {
+            this._model.method = method;
+        }
+        return this;
+    }
+
     setProvider(provider) {
         if (typeof provider === 'string') {
             this._model.hook_provider = provider;
@@ -85,10 +96,11 @@ class Webhook {
         return this._model.save().then(() => this);
     }
 
-    static getHook(hookID) {
+    static getHook(hookID, method) {
         return WebhookModel
             .findOne({
                 id: hookID,
+                method,
             })
             .then((result) => {
                 if (!result) return null;

--- a/routes/index.js
+++ b/routes/index.js
@@ -42,6 +42,7 @@ router.get('/about', AboutController.get);
 router.post('/hooks/github/:hookID', HookHandlerController.github);
 router.post('/hooks/gitlab/:hookID', HookHandlerController.gitlab);
 router.post('/hooks/custom/:hookID', HookHandlerController.custom);
+router.get('/hooks/custom/:hookID', HookHandlerController.custom);
 
 router.get('/settings', checkAuth, SettingsController.get);
 router.get('/settings/:serverID', checkAuth, settingsMiddleware, ServerSettingsController.get);

--- a/test/webhookCollection.test.js
+++ b/test/webhookCollection.test.js
@@ -45,10 +45,51 @@ describe('Webhook database', () => {
         expect(savedEvent.createdBy).toBe(fields.user);
         expect(savedEvent.message).toBe('a cool event has happened');
         expect(savedEvent.provider).toBe('github');
+        expect(savedEvent.method).toBe('POST');
 
         // check hookID format
         expect(savedEvent.hookID).toEqual(expect.stringMatching(/^[0-9a-f]{32}$/));
         expect(savedEvent.secret).toEqual(expect.stringMatching(/^[0-9A-F]{32}$/));
+    });
+
+    test('invalid method - DELETE', () => {
+        const hook = new Webhook()
+            .setGuild(fields.guild)
+            .setChannel(fields.channel)
+            .setCreatedBy(fields.user)
+            .setMessage('a cool event has happened')
+            .setMethod('DELETE')
+            .setProvider('github');
+
+        return expect(hook.save()).rejects.toThrow('validation failed');
+    });
+
+    test('valid method - GET', async () => {
+        const hook = new Webhook()
+            .setGuild(fields.guild)
+            .setChannel(fields.channel)
+            .setCreatedBy(fields.user)
+            .setMessage('a cool event has happened')
+            .setMethod('GET')
+            .setProvider('github');
+
+        expect(hook._mongoId).toBeDefined();
+        const savedEvent = await hook.save();
+        expect(savedEvent.method).toBe('GET');
+    });
+
+    test('valid method - POST', async () => {
+        const hook = new Webhook()
+            .setGuild(fields.guild)
+            .setChannel(fields.channel)
+            .setCreatedBy(fields.user)
+            .setMessage('a cool event has happened')
+            .setMethod('POST')
+            .setProvider('github');
+
+        expect(hook._mongoId).toBeDefined();
+        const savedEvent = await hook.save();
+        expect(savedEvent.method).toBe('POST');
     });
 
     test('missing guild', () => {
@@ -91,7 +132,7 @@ describe('Webhook database', () => {
         return expect(hook.save()).rejects.toThrow('required');
     });
 
-    test('missing providor', () => {
+    test('missing provider', () => {
         const hook = new Webhook()
             .setGuild(fields.guild)
             .setChannel(fields.channel)
@@ -206,9 +247,9 @@ describe('Webhook database', () => {
         return expect(hook.save()).rejects.toThrow('validation failed');
     });
 
-    test('get hook - none', () => expect(Webhook.getHook('d4b85e95ff374064b20869c9c599d47c')).resolves.toBeNull());
+    test('get hook - none', () => expect(Webhook.getHook('d4b85e95ff374064b20869c9c599d47c', 'POST')).resolves.toBeNull());
 
-    test('get hook - one', async () => {
+    test('get hook - POST one', async () => {
         const hook = new Webhook()
             .setGuild(fields.guild)
             .setChannel(fields.channel)
@@ -219,7 +260,42 @@ describe('Webhook database', () => {
         expect(hook._mongoId).toBeDefined();
         const savedEvent = await hook.save();
 
-        const res = await Webhook.getHook(savedEvent.hookID);
+        const res = await Webhook.getHook(savedEvent.hookID, 'POST');
+
+        expect(res).toBeInstanceOf(Webhook);
+
+        expect(res.timestamp).toStrictEqual(savedEvent.timestamp);
+        expect(res._mongoId).toStrictEqual(savedEvent._mongoId);
+        expect(res.secret).toStrictEqual(savedEvent.secret);
+        expect(res.hookID).toStrictEqual(savedEvent.hookID);
+        expect(res.guildID).toStrictEqual(savedEvent.guildID);
+        expect(res.channelID).toStrictEqual(savedEvent.channelID);
+        expect(res.createdBy).toStrictEqual(savedEvent.createdBy);
+        expect(res.message).toStrictEqual(savedEvent.message);
+        expect(res.provider).toStrictEqual(savedEvent.provider);
+    });
+
+    test('get hook - GET one', async () => {
+        const hook1 = new Webhook()
+            .setGuild(fields.guild)
+            .setChannel(fields.channel)
+            .setCreatedBy(fields.user)
+            .setMessage('a cool event has happened')
+            .setProvider('github');
+
+        const hook2 = new Webhook()
+            .setGuild(fields.guild)
+            .setChannel(fields.channel)
+            .setCreatedBy(fields.user)
+            .setMessage('a cool event has happened')
+            .setMethod('GET')
+            .setProvider('github');
+
+        expect(hook1._mongoId).toBeDefined();
+        await hook1.save();
+        const savedEvent = await hook2.save();
+
+        const res = await Webhook.getHook(savedEvent.hookID, 'GET');
 
         expect(res).toBeInstanceOf(Webhook);
 

--- a/views/webhookConfirm.handlebars
+++ b/views/webhookConfirm.handlebars
@@ -7,5 +7,5 @@ To finish setting up this webhook, take this URL and secret token to the platfor
 to start receiving your amazing web hooks.
 </p>
 
-Webhook URL: <code>{{ url }} </code> <br>
+Webhook URL: <code> {{ method }}</code> <code>{{ url }} </code> <br>
 SHHHHHH this is top secret: <code>{{ secret }} </code>

--- a/views/webhookForm.handlebars
+++ b/views/webhookForm.handlebars
@@ -35,6 +35,17 @@
       </div>
 
       <div class="form-group">
+        <label for="method">Select webhook method</label>
+        <div>
+          <select id="method" name="method" aria-describedby="methodHelpBlock" required="required" class="custom-select">
+              <option value="GET" {{#if method}} selected {{/if}} >GET</option>
+              <option value="POST" {{#if method}} selected {{/if}} >POST</option>
+          </select>
+          <span id="methodHelpBlock" class="form-text text-muted">Select the type of HTTP request that will be sent</span>
+        </div>
+      </div>
+
+      <div class="form-group">
         <label for="messageText">Text to send</label>
         <div>
           <input id="messageText" name="messageText" placeholder="An event has happened..." type="text" required="required" class="form-control" value="{{messageText}}">

--- a/views/webhookSettings.handlebars
+++ b/views/webhookSettings.handlebars
@@ -14,6 +14,7 @@
       <thead>
         <tr>
           <th scope="col">Provider</th>
+          <th scope="col">HTTP Method</th>
           <th scope="col">Channel</th>
           <th scope="col">Created By</th>
           <th scope="col">Options</th>
@@ -24,6 +25,7 @@
           {{#each hook}}
               <tr>
                 <th scope="row">{{provider}}</th>
+                <td>{{method}}</td>
                 <td>{{channelName}}</td>
                 <td>{{createdBy}}</td>
                 <td>


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: #303

---

**Describe the pull request:**

This will now allow webhooks to be sent as GET or POST requests. All existing hooks must still be sent as POST requests. 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Run `npm run lint` and ensure linter passes
- [x] Run `npm run test` and ensure tests pass
- [x] Verify that the changes work as expected on Discord
- [x] Verify that the changes work as expected when run using docker
- [x] Update documentation / not applicable
- [x] Update changelog / not applicable
