### PR TITLE
fix: correct promise return value when saving message edits and deletions

### DIFF
--- a/bot/events/messageDeleteLogger.js
+++ b/bot/events/messageDeleteLogger.js
@@ -8,7 +8,10 @@ function deleteHandler(message) {
 
     Message.Message.find(message.guild.id, message.channel.id, message.id)
         .then((messageLog) => {
-            if (messageLog) messageLog.delete().save();
+            if (messageLog) {
+                return messageLog.delete().save();
+            }
+            return null;
         })
         .catch((e) => {
             logger.error('failed to save the message deletion to the database');

--- a/bot/events/messageLogger.js
+++ b/bot/events/messageLogger.js
@@ -15,7 +15,7 @@ function databaseHandler(message) {
         .setContent(message.content, message.createdTimestamp);
 
     MessagePost.save()
-        .then(() => logger.info('Successfully written message to database'))
+        .then(() => logger.debug('Successfully written message to database'))
         .catch((e) => logger.error('failed to save the message to the database', e));
 }
 

--- a/bot/events/messageUpdateLogger.js
+++ b/bot/events/messageUpdateLogger.js
@@ -19,8 +19,9 @@ function databaseHandler(oldM, newM) {
         })
         .then((messageLog) => {
             if (messageLog) {
-                messageLog.setContent(newMessage.content, newMessage.editedTimestamp).save();
+                return messageLog.setContent(newMessage.content, newMessage.editedTimestamp).save();
             }
+            return null;
         })
         .catch((e) => logger.error('failed to save the message update to the database', e));
 }


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Fixes: #361 

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

I belive this will fix those server crashes which I belive is related to the `message.save()` promise not being returned, and then bypassing the error handling. 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Run `npm run lint` and ensure linter passes
- [ ] Run `npm run test` and ensure tests pass
- [ ] Verify that the changes work as expected on Discord
- [ ] Verify that the changes work as expected when run using docker
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable
